### PR TITLE
Fix PP calculation with certain mod combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.7.2 (2022-07-16)
+- Apply acc before mods to fix pp values sometimes calculating incorrectly on certain mod combos
+
 # v0.7.1 (2022-07-12)
 - Updated to [rosu-pp v0.7.1](https://github.com/MaxOhn/rosu-pp/blob/main/CHANGELOG.md#v071-2022-07-12)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rosu-pp-py"
-version = "0.7.1"
+version = "0.7.2"
 requires-python = ">=3.7"
 description = "osu! difficulty and pp calculation for all modes"
 classifiers = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,7 +546,7 @@ impl ScoreParams {
             calculator = calculator.clock_rate(clock_rate);
         }
 
-        calculator.mods(mods);
+        calculator = calculator.mods(mods);
 
         if let Some(acc) = acc {
             calculator = calculator.accuracy(acc);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,6 +546,8 @@ impl ScoreParams {
             calculator = calculator.clock_rate(clock_rate);
         }
 
+        calculator.mods(mods);
+
         if let Some(acc) = acc {
             calculator = calculator.accuracy(acc);
         }
@@ -554,7 +556,7 @@ impl ScoreParams {
             calculator = calculator.score(score);
         }
 
-        calculator.mods(mods)
+        calculator
     }
 }
 


### PR DESCRIPTION
Python bindings were specifying accuracy before mods, which caused things to break internally and provide incorrect values. This PR fixes this bug.