### PR TITLE
Update to py03 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,9 +16,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indoc"
@@ -37,16 +31,6 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
-
-[[package]]
-name = "lock_api"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "memoffset"
@@ -64,29 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,24 +55,24 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a8b1990bd018761768d5e608a13df8bd1ac5f678456e0f301bb93e5f3ea16b"
+checksum = "1962a33ed2a201c637fc14a4e0fd4e06e6edfdeee6a5fede0dab55507ad74cf7"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -121,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650dca34d463b6cdbdb02b1d71bfd6eb6b6816afc708faebb3bac1380ff4aef7"
+checksum = "ab7164b2202753bd33afc7f90a10355a719aa973d1f94502c50d06f3488bc420"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -131,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a7da8fc04a8a2084909b59f29e1b8474decac98b951d77b80b26dc45f046ad"
+checksum = "c6424906ca49013c0829c5c1ed405e20e2da2dc78b82d198564880a704e6a7b7"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -141,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8a199fce11ebb28e3569387228836ea98110e43a804a530a9fd83ade36d513"
+checksum = "82b2f19e153122d64afd8ce7aaa72f06a00f52e34e1d1e74b6d71baea396460a"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -153,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fbbfd7eb553d10036513cb122b888dcd362a945a00b06c165f2ab480d4cc3b"
+checksum = "dd698c04cac17cf0fe63d47790ab311b8b25542f5cb976b65c374035c50f1eef"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -171,15 +132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -206,22 +158,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "smallvec"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
-
-[[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -230,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.4"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "unicode-ident"
@@ -245,46 +185,3 @@ name = "unindent"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
-
-[[package]]
-name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "rosu_pp_py"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.21", features = ["extension-module", "macros"] }
+pyo3 = { version = "0.22", features = ["extension-module", "macros"] }
 rosu-pp = { version = "1.0.0", features = ["sync"] }
 
 [profile.release]

--- a/src/attributes/beatmap.rs
+++ b/src/attributes/beatmap.rs
@@ -178,10 +178,12 @@ impl PyBeatmapAttributesBuilder {
         self.is_convert = is_convert;
     }
 
+    #[pyo3(signature = (mods=None))]
     fn set_mods(&mut self, mods: Option<u32>) {
         self.mods = mods.unwrap_or(0);
     }
 
+    #[pyo3(signature = (clock_rate=None))]
     fn set_clock_rate(&mut self, clock_rate: Option<f64>) {
         self.clock_rate = clock_rate;
     }

--- a/src/difficulty.rs
+++ b/src/difficulty.rs
@@ -179,10 +179,12 @@ impl PyDifficulty {
         PyGradualPerformance::new(self, map)
     }
 
+    #[pyo3(signature = (mods=None))]
     fn set_mods(&mut self, mods: Option<u32>) {
         self.mods = mods.unwrap_or(0);
     }
 
+    #[pyo3(signature = (clock_rate=None))]
     fn set_clock_rate(&mut self, clock_rate: Option<f64>) {
         self.clock_rate = clock_rate;
     }
@@ -211,10 +213,12 @@ impl PyDifficulty {
         self.od_with_mods = od_with_mods;
     }
 
+    #[pyo3(signature = (passed_objects=None))]
     fn set_passed_objects(&mut self, passed_objects: Option<u32>) {
         self.passed_objects = passed_objects;
     }
 
+    #[pyo3(signature = (hardrock_offsets=None))]
     fn set_hardrock_offsets(&mut self, hardrock_offsets: Option<bool>) {
         self.hardrock_offsets = hardrock_offsets;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use error::ConvertError;
 use performance::PyHitResultPriority;
+use pyo3::prelude::PyModuleMethods;
 use pyo3::{pymodule, types::PyModule, Bound, PyResult, Python};
 
 use self::{

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -3,8 +3,8 @@ use std::fmt::{Debug, Formatter, Result as FmtResult};
 use pyo3::pyclass;
 use rosu_pp::model::mode::GameMode;
 
-#[pyclass(name = "GameMode")]
-#[derive(Copy, Clone, Default)]
+#[pyclass(eq, eq_int, name = "GameMode")]
+#[derive(Copy, Clone, Default, PartialEq)]
 pub enum PyGameMode {
     #[default]
     Osu,

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -262,10 +262,12 @@ impl PyPerformance {
         }
     }
 
+    #[pyo3(signature = (mods=None))]
     fn set_mods(&mut self, mods: Option<u32>) {
         self.mods = mods.unwrap_or(0);
     }
 
+    #[pyo3(signature = (clock_rate=None))]
     fn set_clock_rate(&mut self, clock_rate: Option<f64>) {
         self.clock_rate = clock_rate;
     }
@@ -294,46 +296,57 @@ impl PyPerformance {
         self.od_with_mods = od_with_mods;
     }
 
+    #[pyo3(signature = (passed_objects=None))]
     fn set_passed_objects(&mut self, passed_objects: Option<u32>) {
         self.passed_objects = passed_objects;
     }
 
+    #[pyo3(signature = (hardrock_offsets=None))]
     fn set_hardrock_offsets(&mut self, hardrock_offsets: Option<bool>) {
         self.hardrock_offsets = hardrock_offsets;
     }
 
+    #[pyo3(signature = (accuracy=None))]
     fn set_accuracy(&mut self, accuracy: Option<f64>) {
         self.accuracy = accuracy;
     }
 
+    #[pyo3(signature = (combo=None))]
     fn set_combo(&mut self, combo: Option<u32>) {
         self.combo = combo;
     }
 
+    #[pyo3(signature = (n_geki=None))]
     fn set_n_geki(&mut self, n_geki: Option<u32>) {
         self.n_geki = n_geki;
     }
 
+    #[pyo3(signature = (n_katu=None))]
     fn set_n_katu(&mut self, n_katu: Option<u32>) {
         self.n_katu = n_katu;
     }
 
+    #[pyo3(signature = (n300=None))]
     fn set_n300(&mut self, n300: Option<u32>) {
         self.n300 = n300;
     }
 
+    #[pyo3(signature = (n100=None))]
     fn set_n100(&mut self, n100: Option<u32>) {
         self.n100 = n100;
     }
 
+    #[pyo3(signature = (n50=None))]
     fn set_n50(&mut self, n50: Option<u32>) {
         self.n50 = n50;
     }
 
+    #[pyo3(signature = (misses=None))]
     fn set_misses(&mut self, misses: Option<u32>) {
         self.misses = misses;
     }
 
+    #[pyo3(signature = (hitresult_priority=None))]
     fn set_hitresult_priority(&mut self, hitresult_priority: Option<PyHitResultPriority>) {
         self.hitresult_priority = hitresult_priority.unwrap_or_default();
     }
@@ -412,8 +425,8 @@ impl PyPerformance {
     }
 }
 
-#[pyclass(name = "HitResultPriority")]
-#[derive(Copy, Clone, Default)]
+#[pyclass(eq, eq_int, name = "HitResultPriority")]
+#[derive(Copy, Clone, Default, PartialEq)]
 pub enum PyHitResultPriority {
     #[default]
     BestCase,


### PR DESCRIPTION
Updates to py03 0.22 and fixes new errors and deprecation warnings. This adds support for python 3.13